### PR TITLE
Improvements for cgetc()

### DIFF
--- a/libsrc/osic1p/cgetc.c
+++ b/libsrc/osic1p/cgetc.c
@@ -160,8 +160,10 @@ char cgetc (void)
         key = lastKey; // If so, use it.
         lastKey = 0; // Then clear it.
     } else {
-        while ((key = getkey()) != 0)
+        while ((key = getkey()) == 0)
             ; // Wait for key to be pressed.
+        while (getkey() != 0)
+            ; // Wait for key to be released
     }
     return key;
 }

--- a/libsrc/osic1p/cgetc.c
+++ b/libsrc/osic1p/cgetc.c
@@ -27,7 +27,7 @@ const unsigned char keys[8][8] = {
 };
 
 // Table of bitmasks for active keys in each row.
-const unsigned char columnMask[8] = {
+static const unsigned char columnMask[8] = {
     0x20, // Row 0, only ESC key
     0xfe, // Row 1
     0xfe, // Row 2
@@ -39,12 +39,12 @@ const unsigned char columnMask[8] = {
 };
 
 // Bit masks for modifier keys.
-const unsigned char controlMask = 0x40; // Control
-const unsigned char shiftMask = 0x06;   // Left Shift, Right Shift
-const unsigned char lockMask = 0x01;    // Shift Lock
+static const unsigned char controlMask = 0x40; // Control
+static const unsigned char shiftMask = 0x06;   // Left Shift, Right Shift
+static const unsigned char lockMask = 0x01;    // Shift Lock
 
 // Holds last key pressed.
-unsigned char lastKey = 0;
+static unsigned char lastKey = 0;
 
 /*
  * Write to keyboard to select row.


### PR DESCRIPTION
1. Fix problem that cgetc() does not block
1. Fix problem that cscanf() reads multiple characters for a single keypress
1. Make private variables static

This modification is an improvement, but it's not yet fully satisfying, as the cgetc() will only return after the key is released. This is not the common behavior expected from a keyboard. 